### PR TITLE
feat: make pagination metadata key configurable in base serializers

### DIFF
--- a/src/base_serializer.ts
+++ b/src/base_serializer.ts
@@ -216,6 +216,7 @@ export abstract class BaseSerializer<
     UnpackAsTopLevelPaginator<
       ResourcePaginator,
       Wrappers['Wrap'] extends string ? Wrappers['Wrap'] : 'data',
+      Wrappers['MetadataKey'] extends string ? Wrappers['MetadataKey'] : 'metadata',
       Wrappers['PaginationMetaData']
     >
   >
@@ -293,7 +294,9 @@ export abstract class BaseSerializer<
   serializeWithoutWrapping<ResourcePaginator extends PaginatorContract<any, any, any>>(
     paginator: ResourcePaginator,
     resolver?: ContainerResolver<any>
-  ): Promise<UnpackAsTopLevelPaginator<ResourcePaginator, 'data', Wrappers['PaginationMetaData']>>
+  ): Promise<
+    UnpackAsTopLevelPaginator<ResourcePaginator, 'data', 'metadata', Wrappers['PaginationMetaData']>
+  >
 
   /**
    * Serializes any other value by returning it as-is wrapped in a Promise.

--- a/src/base_serializer.ts
+++ b/src/base_serializer.ts
@@ -38,9 +38,11 @@ import {
  * ```typescript
  * class ApiSerializer extends BaseSerializer<{
  *   Wrap: 'data'
+ *   MetadataKey: 'metadata'
  *   PaginationMetaData: { page: number; totalPages: number }
  * }> {
  *   wrap = 'data' as const
+ *   metadataKey = 'metadata' as const
  *
  *   definePaginationMetaData(metaData: any) {
  *     return {
@@ -58,6 +60,7 @@ import {
 export abstract class BaseSerializer<
   Wrappers extends {
     Wrap?: string
+    MetadataKey?: string
     PaginationMetaData?: Record<string, any>
   } = {},
 > {
@@ -65,6 +68,11 @@ export abstract class BaseSerializer<
    * The key name to wrap response data under. Set to undefined to disable wrapping.
    */
   abstract wrap: Wrappers['Wrap']
+
+  /**
+   * The key name to wrap pagination metadata under. Set to undefined to disable wrapping.
+   */
+  abstract metadataKey: Wrappers['MetadataKey']
 
   /**
    * Transforms raw pagination metadata into the desired format for API responses.
@@ -238,10 +246,11 @@ export abstract class BaseSerializer<
 
     if (data instanceof Paginator) {
       const wrapperKey = this.wrap ?? 'data'
+      const metadataKey = this.metadataKey ?? 'metadata'
       return data.resolve(containerResolver, 0, -1).then((value) => {
         return {
           [wrapperKey]: value.data,
-          metadata: this.definePaginationMetaData(value.metadata),
+          [metadataKey]: this.definePaginationMetaData(value.metadata),
         }
       })
     }

--- a/src/base_serializer.ts
+++ b/src/base_serializer.ts
@@ -72,7 +72,7 @@ export abstract class BaseSerializer<
   /**
    * The key name to wrap pagination metadata under. Set to undefined to disable wrapping.
    */
-  abstract metadataKey: Wrappers['MetadataKey']
+  metadataKey: Wrappers['MetadataKey'] | undefined = undefined
 
   /**
    * Transforms raw pagination metadata into the desired format for API responses.

--- a/src/types.ts
+++ b/src/types.ts
@@ -533,18 +533,23 @@ export type UnpackAsTopLevelCollection<T, Wrapper extends string | undefined> =
  *
  * @internal
  */
-export type UnpackAsTopLevelPaginator<T, Wrapper extends string, TransformedMetaData> =
+export type UnpackAsTopLevelPaginator<
+  T,
+  Wrapper extends string,
+  WrapperMeta extends string | 'metadata',
+  TransformedMetaData,
+> =
   T extends PaginatorContract<infer Transformer, any, infer Variant>
     ? TransformedMetaData extends Record<string, any>
       ? Prettify<
           {
             [K in Wrapper]: InferData<Transformer, Variant, -1, 0>[]
-          } & { metadata: TransformedMetaData }
+          } & { [K in WrapperMeta]: TransformedMetaData }
         >
       : Prettify<
           {
             [K in Wrapper]: InferData<Transformer, Variant, -1, 0>[]
-          } & { metadata: any }
+          } & { [K in WrapperMeta]: any }
         >
     : never
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -26,6 +26,24 @@ class WrappedApiSerializer extends BaseSerializer<{
   }
 }
 
+class MetadataKeyApiSerializer extends BaseSerializer<{
+  MetadataKey: 'pagination'
+  PaginationMetaData: {
+    totalItems: number
+    currentPage: number
+  }
+}> {
+  wrap: undefined = undefined
+  metadataKey: 'pagination' = 'pagination'
+  definePaginationMetaData(_: unknown): {
+    totalItems: number
+    currentPage: number
+  } {
+    return { totalItems: 10, currentPage: 10 }
+  }
+}
+
 export const apiSerializer = new ApiSerializer()
 export const wrappedApiSerializer = new WrappedApiSerializer()
+export const metadataKeyApiSerializer = new MetadataKeyApiSerializer()
 export const container = new Container()

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -5,6 +5,7 @@ class ApiSerializer extends BaseSerializer<{
   PaginationMetaData: Record<string, any>
 }> {
   wrap: undefined = undefined
+  metadataKey: undefined = undefined
   definePaginationMetaData(metaData: Record<string, any>) {
     return metaData
   }
@@ -18,6 +19,7 @@ class WrappedApiSerializer extends BaseSerializer<{
   }
 }> {
   wrap: 'data' = 'data'
+  metadataKey: undefined = undefined
   definePaginationMetaData(_: unknown): {
     totalItems: number
     currentPage: number

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -5,7 +5,6 @@ class ApiSerializer extends BaseSerializer<{
   PaginationMetaData: Record<string, any>
 }> {
   wrap: undefined = undefined
-  metadataKey: undefined = undefined
   definePaginationMetaData(metaData: Record<string, any>) {
     return metaData
   }
@@ -19,7 +18,6 @@ class WrappedApiSerializer extends BaseSerializer<{
   }
 }> {
   wrap: 'data' = 'data'
-  metadataKey: undefined = undefined
   definePaginationMetaData(_: unknown): {
     totalItems: number
     currentPage: number

--- a/tests/types.spec.ts
+++ b/tests/types.spec.ts
@@ -9,7 +9,7 @@
 
 import { test } from '@japa/runner'
 import { debug } from '../src/debug.ts'
-import { apiSerializer, container } from './helpers.ts'
+import { apiSerializer, container, metadataKeyApiSerializer } from './helpers.ts'
 import { User } from './fixtures/models/user.ts'
 import { Post } from './fixtures/models/posts.ts'
 import { Email } from './fixtures/models/email.ts'
@@ -473,6 +473,36 @@ test.group('Types | Fixtures', () => {
     }>()
 
     expectTypeOf(userDataObject).toEqualTypeOf<UserData['basicInfo']>()
+  })
+
+  test('infer custom pagination metadata key', async ({ expectTypeOf }) => {
+    const user = new User()
+    UserTransformer
+    const result = await metadataKeyApiSerializer.serialize(
+      UserTransformer.paginate([user], {}).useVariant('basicInfo'),
+      container.createResolver()
+    )
+
+    expectTypeOf(result).toEqualTypeOf<{
+      data: {
+        id: number
+        name: string
+        profile?:
+          | {
+              id: number
+              twitterHandle: string | null
+              githubUsername: string | null
+            }
+          | null
+          | undefined
+      }[]
+      pagination: {
+        totalItems: number
+        currentPage: number
+      }
+    }>()
+
+    expectTypeOf(result).not.toHaveProperty('metadata')
   })
 
   test('pick and method method to filter out functions', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

[Discussion #5097](https://github.com/orgs/adonisjs/discussions/5097)

### ❓ Type of change

* [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
* [ ] 👌 Enhancement (improving an existing functionality like performance)
* [X] ✨ New feature (a non-breaking change that adds functionality)
* [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This pull request implements the changes discussed in Discussion #5097.

It updates the current behavior to align with the proposed approach from the discussion and introduces a breaking change for existing consumers relying on the previous behavior.

If there is a more elegant way to achieve the same result, I would be happy to adjust the implementation accordingly :smile: 

### 📝 Checklist

* [x] I have linked an issue or discussion.
* [ ] I have updated the documentation accordingly.