### PR TITLE
chore: corrects the documentation for `omit` method

### DIFF
--- a/src/base_transformer.ts
+++ b/src/base_transformer.ts
@@ -249,7 +249,7 @@ export abstract class BaseTransformer<T> {
    * ```ts
    * class UserTransformer extends BaseTransformer<User> {
    *   toObject() {
-   *     return this.omit(this.resource, ['password', 'internalId'])
+   *     return this.omit(this.resource.toAttributes(), ['password', 'internalId'])
    *   }
    * }
    * ```


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `omit` method from `base_transformer.ts` stated in its JSDoc that you should use `this.resource` instead of `this.resource.toAttributes()`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.
