### PR TITLE
feat: attach phantom identity to InferData for tooling

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -355,9 +355,7 @@ export type ExtractTransformerVariants<Transformer> = Exclude<
  * ```
  */
 export type ResourceDataTypes =
-  | JSONDataTypes
-  | CollectionContract<any, any, any>
-  | ItemContract<any, any, any>
+  JSONDataTypes | CollectionContract<any, any, any> | ItemContract<any, any, any>
 
 /**
  * A record of resource data types. This is what every transformer
@@ -395,23 +393,16 @@ export type UnpackKeyValue<
 > = [Value[0]] extends [never]
   ? SerializeJSONTypes<Value[1]>
   : Value[0] extends ItemContract<infer Transformer, infer LocalMaxDepth, infer Variant>
-    ?
-        | InferData<
+    ? | InferData<Transformer, Variant, MaxDepth extends -1 ? LocalMaxDepth : MaxDepth, Next[Depth]>
+      | SerializeJSONTypes<Value[1]>
+    : Value[0] extends CollectionContract<infer Transformer, infer LocalMaxDepth, infer Variant>
+      ? | InferData<
             Transformer,
             Variant,
             MaxDepth extends -1 ? LocalMaxDepth : MaxDepth,
             Next[Depth]
-          >
+          >[]
         | SerializeJSONTypes<Value[1]>
-    : Value[0] extends CollectionContract<infer Transformer, infer LocalMaxDepth, infer Variant>
-      ?
-          | InferData<
-              Transformer,
-              Variant,
-              MaxDepth extends -1 ? LocalMaxDepth : MaxDepth,
-              Next[Depth]
-            >[]
-          | SerializeJSONTypes<Value[1]>
       : SerializeJSONTypes<Value[1]>
 
 /**
@@ -450,11 +441,13 @@ export type LimitDepth<Key, Value, MaxDepth extends number, Depth extends number
  * @internal
  */
 export type UnpackOptionalValues<Data, MaxDepth extends number, Depth extends number> = {
-  [O in {
-    [K in keyof Data]: [undefined] extends [Data[K]]
-      ? LimitDepth<K, SplitItm<Data[K]>[0], MaxDepth, Depth>
-      : never
-  }[keyof Data]]?: UnpackKeyValue<SplitItm<Data[O]>, MaxDepth, Depth>
+  [
+    O in {
+      [K in keyof Data]: [undefined] extends [Data[K]]
+        ? LimitDepth<K, SplitItm<Data[K]>[0], MaxDepth, Depth>
+        : never
+    }[keyof Data]
+  ]?: UnpackKeyValue<SplitItm<Data[O]>, MaxDepth, Depth>
 }
 
 /**
@@ -469,11 +462,13 @@ export type UnpackOptionalValues<Data, MaxDepth extends number, Depth extends nu
  * @internal
  */
 export type UnpackRequiredValues<Data, MaxDepth extends number, Depth extends number> = {
-  [O in {
-    [K in keyof Data]: [undefined] extends [Data[K]]
-      ? never
-      : LimitDepth<K, SplitItm<Data[K]>[0], MaxDepth, Depth>
-  }[keyof Data]]: UnpackKeyValue<SplitItm<Data[O]>, MaxDepth, Depth>
+  [
+    O in {
+      [K in keyof Data]: [undefined] extends [Data[K]]
+        ? never
+        : LimitDepth<K, SplitItm<Data[K]>[0], MaxDepth, Depth>
+    }[keyof Data]
+  ]: UnpackKeyValue<SplitItm<Data[O]>, MaxDepth, Depth>
 }
 
 /**
@@ -605,11 +600,105 @@ export type UnpackTopLevelValues<Data> = Prettify<
   }
 >
 
+declare const inferTransformerBrand: unique symbol
+declare const inferVariantBrand: unique symbol
+
+/**
+ * Phantom identity attached to {@link InferData}. Unique-symbol keys carry the
+ * transformer class and variant after {@link UnpackValues} has expanded the
+ * output to a plain object.
+ *
+ * Without this, {@link UnpackValues} erases the transformer class, so tooling
+ * that inspects the expanded object cannot tell which transformer produced it.
+ * The brands are optional unique symbols: they do not exist at runtime, they
+ * are skipped by `{ [key: string]: ... }` index signatures (so the result stays
+ * assignable to {@link JSONDataTypes}), and OpenAPI generators that walk string
+ * keys ignore them automatically.
+ *
+ * Must be a type alias, not an interface. Interfaces do not receive an implicit
+ * index signature, which makes them unassignable to {@link JSONDataTypes} and
+ * hides generic mapped keys during assignability checks.
+ *
+ * @template Transformer - The transformer class that produced the data
+ * @template Variant - The variant method name used to produce the data
+ *
+ * ```typescript
+ * // OpenAPI / client codegen: recover the transformer after unpacking so `$ref`
+ * // names can be `User` / `Guest` instead of collapsing both to `{ id, name }`.
+ * class UserTransformer extends BaseTransformer<User> {
+ *   toObject() {
+ *     return { id: this.resource.id, name: this.resource.name }
+ *   }
+ * }
+ * class GuestTransformer extends BaseTransformer<Guest> {
+ *   toObject() {
+ *     return { id: this.resource.id, name: this.resource.name }
+ *   }
+ * }
+ *
+ * type UserData = InferData<UserTransformer>
+ * type GuestData = InferData<GuestTransformer>
+ * type SameJson = InferDataShape<UserData> extends InferDataShape<GuestData> ? true : false
+ * // true — the JSON fields match. Tooling still reads InferDataIdentity type
+ * // arguments (and unique-symbol property types) to name `User` vs `Guest`.
+ *
+ * // Variants stay distinct even when they return the same fields, so an RPC
+ * // layer or SDK can dispatch `toObject` vs `toSummary` from the payload type.
+ * type ObjectOutput = InferData<UserTransformer, 'toObject'>
+ * type SummaryOutput = InferData<UserTransformer, 'toSummary'>
+ *
+ * // Gotcha: unique-symbol keys appear in `keyof T`. Intersect with `string`
+ * // (or use {@link InferDataKeys}) to keep only serialized field names.
+ * type Wrong = keyof UserData
+ * // serialized fields plus unique-symbol identity keys
+ * type Fields = keyof UserData & string
+ * // 'id' | 'name'
+ * ```
+ */
+export type InferDataIdentity<Transformer, Variant extends string> = {
+  readonly [inferTransformerBrand]?: Transformer
+  readonly [inferVariantBrand]?: Variant
+}
+
+/**
+ * Field names of an {@link InferData} result, excluding unique-symbol identity
+ * keys. Prefer this (or `keyof T & string`) when mapping over transformer output.
+ *
+ * @template T - An {@link InferData} result (or any branded object type)
+ *
+ * ```typescript
+ * type UserData = InferData<UserTransformer>
+ * type Fields = InferDataKeys<UserData>
+ * // 'id' | 'name' | 'posts'
+ * ```
+ */
+export type InferDataKeys<T> = keyof T & string
+
+/**
+ * JSON field types of {@link InferData} without phantom identity keys.
+ * Recursively drops unique-symbol brands from nested transformer outputs.
+ *
+ * @template T - An {@link InferData} result (or a structure containing them)
+ *
+ * ```typescript
+ * type UserData = InferData<UserTransformer>
+ * type UserJson = InferDataShape<UserData>
+ * // { id: number; name: string; posts: { id: number; title: string }[] }
+ * ```
+ */
+export type InferDataShape<T> = T extends readonly (infer Item)[]
+  ? InferDataShape<Item>[]
+  : T extends object
+    ? { [K in keyof T as K extends string ? K : never]: InferDataShape<T[K]> }
+    : T
+
 /**
  * Infers the serialized data structure of a transformer by extracting the return type
  * of a specific variant method and unpacking it recursively.
  *
  * This is the primary type used to extract the TypeScript type of a transformer's output.
+ * The result is the unpacked object shape intersected with {@link InferDataIdentity},
+ * so the originating transformer and variant can be recovered after unpacking.
  *
  * @template Transformer - The transformer class to infer data from
  * @template Variant - The variant method name to use (defaults to 'toObject')
@@ -628,7 +717,10 @@ export type UnpackTopLevelValues<Data> = Prettify<
  * }
  *
  * type UserData = InferData<UserTransformer>
- * // Result: { id: number; name: string; posts: PostData[] }
+ * // Result: { id: number; name: string; posts: PostData[] } & InferDataIdentity<UserTransformer, 'toObject'>
+ *
+ * type Fields = InferDataKeys<UserData>
+ * // 'id' | 'name' | 'posts'
  * ```
  */
 export type InferData<
@@ -637,7 +729,8 @@ export type InferData<
   MaxDepth extends number = -1,
   Depth extends number = 0,
 > = Transformer extends { [K in Variant]: (...args: any[]) => unknown }
-  ? UnpackValues<Awaited<ReturnType<Transformer[Variant]>>, MaxDepth, Depth>
+  ? UnpackValues<Awaited<ReturnType<Transformer[Variant]>>, MaxDepth, Depth> &
+      InferDataIdentity<Transformer, Variant>
   : never
 
 /**
@@ -665,16 +758,18 @@ export type InferData<
  * ```
  */
 export type InferVariants<Transformer, MaxDepth extends number = -1, Depth extends number = 0> = {
-  [O in {
-    [K in keyof Transformer]: 'toObject' extends K
-      ? never
-      : K extends keyof BaseTransformer<any>
+  [
+    O in {
+      [K in keyof Transformer]: 'toObject' extends K
         ? never
-        : Transformer[K] extends (...args: any[]) => unknown
-          ? K
-          : never
-  }[keyof Transformer] &
-    string]: InferData<Transformer, O, MaxDepth, Depth>
+        : K extends keyof BaseTransformer<any>
+          ? never
+          : Transformer[K] extends (...args: any[]) => unknown
+            ? K
+            : never
+    }[keyof Transformer] &
+      string
+  ]: InferData<Transformer, O, MaxDepth, Depth>
 }
 
 /**

--- a/tests/transformer.spec.ts
+++ b/tests/transformer.spec.ts
@@ -9,7 +9,7 @@
 
 import { test } from '@japa/runner'
 import { inject } from '@adonisjs/fold'
-import { type InferData } from '../src/types.ts'
+import { type InferData, type InferDataShape } from '../src/types.ts'
 import { type Paginator } from '../src/paginator.ts'
 import { BaseTransformer } from '../src/base_transformer.ts'
 import { apiSerializer, container, wrappedApiSerializer } from './helpers.ts'
@@ -35,7 +35,7 @@ test.group('Transformer', () => {
       UserTransformer.transform(null)!,
       container.createResolver()
     )
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       id: number
       fullName: string | null
       email: string
@@ -62,7 +62,7 @@ test.group('Transformer', () => {
       UserTransformer.transform(undefined as any)!,
       container.createResolver()
     )
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       id: number
       fullName: string | null
       email: string
@@ -95,7 +95,7 @@ test.group('Transformer', () => {
     )
 
     assert.deepEqual(userData, { user: null })
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       user: {
         id: number
         fullName: string | null
@@ -124,7 +124,11 @@ test.group('Transformer', () => {
       UserTransformer.transform(undefined as any)!,
       container.createResolver()
     )
-    expectTypeOf(userData).toEqualTypeOf<{ id: number; fullName: string | null; email: string }>()
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
+      id: number
+      fullName: string | null
+      email: string
+    }>()
   }).throws(
     'Cannot transform undefined value. Use "this.whenLoaded(value)" to allow undefined values'
   )
@@ -155,7 +159,11 @@ test.group('Transformer', () => {
       container.createResolver()
     )
     assert.deepEqual(userData, { id: 1, fullName: null, email: 'foo@bar.com' })
-    expectTypeOf(userData).toEqualTypeOf<{ id: number; fullName: string | null; email: string }>()
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
+      id: number
+      fullName: string | null
+      email: string
+    }>()
   })
 
   test('transform with relationships', async ({ assert, expectTypeOf }) => {
@@ -212,7 +220,7 @@ test.group('Transformer', () => {
       fullName: null,
       emails: [{ id: 1, email: 'foo@bar.com', isVerified: true }],
     })
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       id: number
       fullName: string | null
       emails: { id: number; email: string; isVerified: boolean }[]
@@ -273,7 +281,7 @@ test.group('Transformer', () => {
         emails: [{ id: 1, email: 'foo@bar.com', isVerified: true }],
       },
     ])
-    expectTypeOf(userData).toEqualTypeOf<
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<
       {
         id: number
         fullName: string | null
@@ -373,7 +381,7 @@ test.group('Transformer', () => {
       fullName: null,
       emails: undefined,
     })
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       id: number
       fullName: string | null
       emails?: { id: number; email: string; isVerified: boolean }[] | undefined
@@ -437,7 +445,7 @@ test.group('Transformer', () => {
       fullName: null,
       emails: [{ id: 1, email: 'foo@bar.com', isVerified: true }],
     })
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       id: number
       fullName: string | null
       emails?: { id: number; email: string; isVerified: boolean }[] | undefined
@@ -494,7 +502,7 @@ test.group('Transformer', () => {
       container.createResolver()
     )
 
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       id: number
       fullName: string | null
       emails?:
@@ -602,7 +610,7 @@ test.group('Transformer', () => {
         "id": 1,
       }
     `)
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       id: number
       fullName: string | null
       emails?:
@@ -683,7 +691,7 @@ test.group('Transformer', () => {
       container.createResolver()
     )
     assert.deepEqual(userData, { id: 1, fullName: null, email: null })
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       id: number
       fullName: string | null
       email: {
@@ -734,7 +742,7 @@ test.group('Transformer', () => {
       UserTransformer.transform(user),
       container.createResolver()
     )
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       id: number
       fullName: string | null
       email: {
@@ -773,7 +781,7 @@ test.group('Transformer', () => {
       container.createResolver()
     )
     assert.deepEqual(userData, { id: 1, fullName: null, email: 'foo@bar.com' })
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       id: number
       fullName: string | null
       email: string
@@ -806,7 +814,7 @@ test.group('Transformer', () => {
       container.createResolver()
     )
     assert.deepEqual(userData, [{ id: 1, fullName: null, email: 'foo@bar.com' }])
-    expectTypeOf(userData).toEqualTypeOf<
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<
       {
         id: number
         fullName: string | null
@@ -866,7 +874,7 @@ test.group('Transformer', () => {
       id: 1,
       fullName: null,
     })
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       id: number
       fullName: string | null
     }>()
@@ -924,7 +932,7 @@ test.group('Transformer', () => {
       fullName: null,
     })
 
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       id: number
       fullName: string | null
     }>()
@@ -983,7 +991,7 @@ test.group('Transformer', () => {
         fullName: null,
       },
     ])
-    expectTypeOf(userData).toEqualTypeOf<
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<
       {
         id: number
         fullName: string | null
@@ -1031,7 +1039,7 @@ test.group('Transformer', () => {
       email: 'foo@bar.com',
       loggingLevel: 'info',
     })
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       id: number
       fullName: string | null
       email: string
@@ -1086,7 +1094,7 @@ test.group('Transformer', () => {
       fullName: null,
       emails: [{ id: 1, email: 'foo@bar.com' }],
     })
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       id: number
       fullName: string | null
       emails: { id: number; email: string }[]
@@ -1128,7 +1136,7 @@ test.group('Transformer', () => {
         currentPage: 1,
       },
     })
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       data: {
         id: number
         fullName: string | null
@@ -1208,7 +1216,7 @@ test.group('Transformer', () => {
         emails: [{ id: 1, email: 'foo@bar.com' }],
       },
     ])
-    expectTypeOf(userData).toEqualTypeOf<
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<
       {
         id: number
         fullName: string | null
@@ -1257,7 +1265,7 @@ test.group('Transformer', () => {
       data: [{ id: 1, email: 'foo@bar.com', isVerified: true }],
       metadata: {},
     })
-    expectTypeOf(emailData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof emailData>>().toEqualTypeOf<{
       data: {
         id: number
         email: string
@@ -1309,7 +1317,7 @@ test.group('Transformer', () => {
         currentPage: 1,
       },
     })
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       data: {
         id: number
         fullName: string | null
@@ -1392,7 +1400,7 @@ test.group('Transformer', () => {
       },
     })
 
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       data: {
         id: number
         fullName: string | null
@@ -1461,7 +1469,7 @@ test.group('Transformer', () => {
       },
     })
 
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       data: {
         id: number
         fullName: string | null
@@ -1539,7 +1547,7 @@ test.group('Transformer | wrapping', () => {
     )
     type UserData = InferData<UserTransformer>
 
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       data: { id: number; fullName: string | null; email: string }
     }>()
     expectTypeOf(userData).toEqualTypeOf<{ data: UserData }>()
@@ -1575,9 +1583,10 @@ test.group('Transformer | wrapping', () => {
     type UserData = InferData<UserTransformer>
 
     expectTypeOf(userData).toEqualTypeOf<{ data: UserData[] } & { metadata?: never }>()
-    expectTypeOf(userData).toEqualTypeOf<
-      { data: { id: number; fullName: string | null; email: string }[] } & { metadata?: never }
-    >()
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
+      data: { id: number; fullName: string | null; email: string }[]
+      metadata?: never
+    }>()
 
     assert.deepEqual(userData, { data: [{ id: 1, fullName: null, email: 'foo@bar.com' }] })
   })
@@ -1610,7 +1619,7 @@ test.group('Transformer | wrapping', () => {
     type UserData = InferData<UserTransformer>
 
     expectTypeOf(userData.data).toEqualTypeOf<UserData[]>()
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       data: { id: number; fullName: string | null; email: string }[]
       metadata: {
         currentPage: number
@@ -1720,7 +1729,7 @@ test.group('Transformer | wrapping', () => {
     type PostData = InferData<PostTransformer>
 
     expectTypeOf(postData.data).toEqualTypeOf<PostData>()
-    expectTypeOf(postData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof postData>>().toEqualTypeOf<{
       data: {
         id: number
         title: string
@@ -1769,7 +1778,7 @@ test.group('Transformer | wrapping', () => {
     )
     type UserData = InferData<UserTransformer>
 
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       data: {
         user: { id: number; fullName: string | null; email: string }
       }
@@ -1816,7 +1825,7 @@ test.group('Transformer | wrapping', () => {
     type UserData = InferData<UserTransformer>
 
     expectTypeOf(userData).toEqualTypeOf<{ user: UserData }>()
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       user: { id: number; fullName: string | null; email: string }
     }>()
 
@@ -1856,7 +1865,7 @@ test.group('Transformer | wrapping', () => {
     type UserData = InferData<UserTransformer>
 
     expectTypeOf(userData).toEqualTypeOf<UserData>()
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       id: number
       fullName: string | null
       email: string
@@ -1896,7 +1905,9 @@ test.group('Transformer | wrapping', () => {
     type UserData = InferData<UserTransformer>
 
     expectTypeOf(userData).toEqualTypeOf<UserData[]>()
-    expectTypeOf(userData).toEqualTypeOf<{ id: number; fullName: string | null; email: string }[]>()
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<
+      { id: number; fullName: string | null; email: string }[]
+    >()
 
     assert.deepEqual(userData, [{ id: 1, fullName: null, email: 'foo@bar.com' }])
   })
@@ -1934,7 +1945,7 @@ test.group('Transformer | wrapping', () => {
     type UserData = InferData<UserTransformer>
 
     expectTypeOf(userData).toEqualTypeOf<{ user: UserData }>()
-    expectTypeOf(userData).toEqualTypeOf<{
+    expectTypeOf<InferDataShape<typeof userData>>().toEqualTypeOf<{
       user: { id: number; fullName: string | null; email: string }
     }>()
 

--- a/tests/types.spec.ts
+++ b/tests/types.spec.ts
@@ -22,6 +22,9 @@ import { ProfileTransformer } from './fixtures/transformers/profile.ts'
 import {
   type InferVariants,
   type InferData,
+  type InferDataKeys,
+  type InferDataShape,
+  type InferDataIdentity,
   type ResourceData,
   type ExtractTransformerVariants,
 } from '../src/types.ts'
@@ -63,7 +66,7 @@ test.group('Types', () => {
     type ExampleData = InferData<typeof exampleTransformer>
     debug('%O', exampleDataObject)
 
-    expectTypeOf<ExampleData>().toEqualTypeOf<{
+    expectTypeOf<InferDataShape<ExampleData>>().toEqualTypeOf<{
       id: number
       profile: {
         id: number
@@ -115,7 +118,7 @@ test.group('Types', () => {
     type ExampleData = InferData<typeof exampleTransformer>
     debug('%O', exampleDataObject)
 
-    expectTypeOf<ExampleData>().toEqualTypeOf<{
+    expectTypeOf<InferDataShape<ExampleData>>().toEqualTypeOf<{
       id: number
       profile: {
         id: number
@@ -172,7 +175,7 @@ test.group('Types', () => {
     type ExampleData = InferData<typeof exampleTransformer>
     debug('%O', exampleDataObject)
 
-    expectTypeOf<ExampleData>().toEqualTypeOf<{
+    expectTypeOf<InferDataShape<ExampleData>>().toEqualTypeOf<{
       id: number
       profile?:
         | {
@@ -247,7 +250,7 @@ test.group('Types', () => {
       container.createResolver()
     )
     type ExampleData = InferData<typeof exampleTransformer>
-    expectTypeOf<ExampleData>().toEqualTypeOf<{
+    expectTypeOf<InferDataShape<ExampleData>>().toEqualTypeOf<{
       id: number
       scores: bigint
     }>()
@@ -267,7 +270,7 @@ test.group('Types | Fixtures', () => {
     type PostData = InferData<typeof postTransformer>
     debug('%O', postDataObject)
 
-    expectTypeOf<PostData>().toEqualTypeOf<{
+    expectTypeOf<InferDataShape<PostData>>().toEqualTypeOf<{
       id: number
       title: string
       config: { hello: string } | boolean
@@ -326,7 +329,7 @@ test.group('Types | Fixtures', () => {
 
     debug('%o', userDataObject)
 
-    expectTypeOf<UserData>().toEqualTypeOf<{
+    expectTypeOf<InferDataShape<UserData>>().toEqualTypeOf<{
       id: number
       name: string
       profile?:
@@ -388,7 +391,7 @@ test.group('Types | Fixtures', () => {
 
     debug('%O', profileDataObject)
 
-    expectTypeOf<ProfileData>().toEqualTypeOf<{
+    expectTypeOf<InferDataShape<ProfileData>>().toEqualTypeOf<{
       id: number
       twitterHandle: string | null
       githubUsername: string | null
@@ -423,7 +426,7 @@ test.group('Types | Fixtures', () => {
 
     debug('%o', emailDataObject)
 
-    expectTypeOf<EmailData>().toEqualTypeOf<{
+    expectTypeOf<InferDataShape<EmailData>>().toEqualTypeOf<{
       id: number
       email: string
       is_verified: boolean
@@ -457,7 +460,7 @@ test.group('Types | Fixtures', () => {
     type UserData = InferVariants<typeof userTransformer>
     debug('%O', userDataObject)
 
-    expectTypeOf<UserData>().toEqualTypeOf<{
+    expectTypeOf<InferDataShape<UserData>>().toEqualTypeOf<{
       basicInfo: {
         id: number
         name: string
@@ -564,7 +567,7 @@ test.group('Types | Fixtures', () => {
     type TransformerOutput = InferData<typeof transformer>
 
     // Verify the final output doesn't include omitted properties
-    expectTypeOf<TransformerOutput>().toEqualTypeOf<{
+    expectTypeOf<InferDataShape<TransformerOutput>>().toEqualTypeOf<{
       id: number
       name: string
       email: string
@@ -573,5 +576,58 @@ test.group('Types | Fixtures', () => {
 
     expectTypeOf(output).not.toHaveProperty('password')
     expectTypeOf(output).not.toHaveProperty('internalId')
+  })
+
+  test('attaches phantom identity without changing the JSON shape', ({ expectTypeOf }) => {
+    class UserLikeTransformer extends BaseTransformer<{}> {
+      toObject() {
+        return { id: 1, name: 'user' }
+      }
+    }
+    class GuestLikeTransformer extends BaseTransformer<{}> {
+      toObject() {
+        return { id: 1, name: 'guest' }
+      }
+    }
+
+    type UserLike = InferData<UserLikeTransformer>
+    type GuestLike = InferData<GuestLikeTransformer>
+
+    expectTypeOf<InferDataShape<UserLike>>().toEqualTypeOf<{ id: number; name: string }>()
+    expectTypeOf<InferDataShape<GuestLike>>().toEqualTypeOf<{ id: number; name: string }>()
+    expectTypeOf<UserLike>().toMatchTypeOf<InferDataIdentity<UserLikeTransformer, 'toObject'>>()
+    expectTypeOf<GuestLike>().toMatchTypeOf<InferDataIdentity<GuestLikeTransformer, 'toObject'>>()
+  })
+
+  test('preserves variant identity for identical JSON shapes', ({ expectTypeOf }) => {
+    class ExampleTransformer extends BaseTransformer<{}> {
+      toObject() {
+        return { id: 1 }
+      }
+      toSummary() {
+        return { id: 1 }
+      }
+    }
+
+    type ObjectOutput = InferData<ExampleTransformer, 'toObject'>
+    type SummaryOutput = InferData<ExampleTransformer, 'toSummary'>
+    type IsEqual<A, B> =
+      (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false
+
+    expectTypeOf<InferDataShape<ObjectOutput>>().toEqualTypeOf<InferDataShape<SummaryOutput>>()
+    expectTypeOf<IsEqual<ObjectOutput, SummaryOutput>>().toEqualTypeOf<false>()
+  })
+
+  test('excludes identity brands from keyof T & string', ({ expectTypeOf }) => {
+    class ExampleTransformer extends BaseTransformer<{}> {
+      toObject() {
+        return { id: 1, name: 'example' }
+      }
+    }
+
+    type ExampleData = InferData<ExampleTransformer>
+    expectTypeOf<InferDataKeys<ExampleData>>().toEqualTypeOf<'id' | 'name'>()
+    expectTypeOf<keyof ExampleData & string>().toEqualTypeOf<'id' | 'name'>()
+    expectTypeOf<keyof ExampleData extends string ? true : false>().toEqualTypeOf<false>()
   })
 })


### PR DESCRIPTION
## Summary

`InferData` currently unpacks a transformer into a plain object via `UnpackValues`. After that expansion, the TypeScript type no longer carries which transformer class or variant produced the payload. Two transformers that serialize to `{ id: number; name: string }` become indistinguishable, which makes schema generation, client codegen, and similar tooling guess from the JSON shape alone.

This PR intersects `InferData` with `InferDataIdentity`: optional unique-symbol keys that hold the transformer and variant. They do not exist at runtime, they are skipped by `{ [key: string]: ... }` index signatures (so the result stays assignable to `JSONDataTypes`), and generators that walk string keys ignore them automatically.

`InferDataIdentity` must be a **type alias**, not an interface. Interfaces do not receive an implicit index signature, which makes them unassignable to `JSONDataTypes` and hides generic mapped keys.

## Why this is needed

We hit this while generating OpenAPI from AdonisJS transformers. After unpacking, the generator only saw `{ id, name, ... }` and could not name `$ref`s after the transformer (`User` vs `Guest`), even when those types came from different classes.

The identity brands let tooling recover:

- the transformer class (for schema / `$ref` names)
- the variant (`toObject` vs `toSummary`) when several methods return the same fields

## Other use cases

**OpenAPI / JSON Schema.** Walk the unpacked object, skip unique-symbol keys, and use the `InferDataIdentity` type arguments to name components. Two transformers with the same JSON shape can still emit `User` and `Guest` instead of one shared schema.

**Client SDK / codegen.** Map a payload type back to the transformer that produced it when generating clients or registering handlers.

**RPC / variant dispatch.** `InferData<UserTransformer>` and `InferData<UserTransformer, 'toSummary'>` stay distinguishable at the type-checker level even if both variants return `{ id: number }`, so an SDK can pick the right method from the payload type.

```ts
type UserData = InferData<UserTransformer>
type GuestData = InferData<GuestTransformer>

type SameJson = InferDataShape<UserData> extends InferDataShape<GuestData> ? true : false
// true — the JSON fields match. Tooling still reads InferDataIdentity
// type arguments to name User vs Guest.
```

## Gotcha: `keyof T & string`

Unique-symbol keys **do** appear in `keyof InferData<T>`. Intersect with `string` (or use the new `InferDataKeys<T>` helper) to keep only serialized field names:

```ts
type UserData = InferData<UserTransformer>

type Wrong = keyof UserData
// serialized fields plus unique-symbol identity keys

type Fields = keyof UserData & string
// 'id' | 'name' | 'posts'

type Fields = InferDataKeys<UserData> // same thing
```

`InferDataShape<T>` recursively drops the brands when you need the JSON-only object type (exact `toEqualTypeOf` comparisons, mapped types that must not see identity symbols).

Exact type equality against a raw object literal now needs `InferDataShape` (the existing tests were updated accordingly). Structural `extends` still succeeds because the brands are optional, so a serialized value remains assignable to `InferData`.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (64 passing, including new identity / `keyof T & string` cases)
- [x] Confirm OpenAPI (or similar) generators can read `InferDataIdentity` alias type arguments after unpacking


Made with [Cursor](https://cursor.com)